### PR TITLE
Update metadata SQL for corpus changes

### DIFF
--- a/sql/metadata.sql
+++ b/sql/metadata.sql
@@ -1,139 +1,112 @@
 WITH
--- field_name_scores AS (
---   SELECT
---     merged_id,
---     name,
---     field.score AS score
---   FROM
---     fields_of_study_v2.field_scores
---   CROSS JOIN
---     UNNEST(fields) AS field
---   LEFT JOIN
---     fields_of_study_v2.field_meta
---     ON
---       field_id = field.id
---   WHERE
---     (level = 1)),
---
--- field_order AS (
---   SELECT
---     merged_id,
---     name,
---     score,
---     ROW_NUMBER() OVER(PARTITION BY merged_id ORDER BY score DESC) AS row_num
---   FROM
---     field_name_scores),
---
--- top_fields AS (
---   SELECT
---     merged_id,
---     ARRAY_AGG(name ORDER BY score DESC) AS top_level1_fields
---   FROM
---     field_order
---   WHERE
---     (
---       row_num < 4
---     ) AND (
---       merged_id IN (
---         SELECT merged_id
---         FROM
---           literature.papers
---         WHERE
---           (
---             title_english IS NOT NULL
---           ) AND (abstract_english IS NOT NULL) AND (LENGTH(abstract_english) > 500) AND (year > 2010)
---       )
---     )
---   GROUP BY merged_id
--- ),
 
 ai_pubs AS (
   SELECT
-    orig_id,
-    ai OR nlp OR cv OR robotics AS is_ai,
-    nlp AS is_nlp,
-    cv AS is_cv,
-    robotics AS is_robotics,
-    cyber AS is_cyber
+    sources.orig_id,
+    predictions.ai
+    OR predictions.nlp
+    OR predictions.cv
+    OR predictions.robotics AS is_ai,
+    predictions.nlp AS is_nlp,
+    predictions.cv AS is_cv,
+    predictions.robotics AS is_robotics,
+    predictions.cyber AS is_cyber
   FROM
-    openalex_article_classification.predictions
+    literature.sources
+  INNER JOIN
+    article_classification.predictions
+    USING (merged_id)
+  WHERE sources.dataset = "openalex"
 ),
 
 ai_safety_pubs AS (
   SELECT
-    orig_id,
-    preds_str AS is_ai_safety
+    sources.orig_id,
+    ai_safety_predictions.preds_str AS is_ai_safety
   FROM
-    ai_safety_openalex.ai_safety_predictions
+    literature.sources
+  INNER JOIN
+    ai_safety_datasets.ai_safety_predictions
+    USING (merged_id)
+  WHERE sources.dataset = "openalex"
 ),
 
 chip_pubs AS (
   SELECT
-    orig_id,
-    label AS is_chip_design_fabrication
+    sources.orig_id,
+    if(chip_predictions.merged_id IS NULL, FALSE, TRUE)
+      AS is_chip_design_fabrication
   FROM
-    vertex_batches_us.chip_classifier_predictions
-  INNER JOIN
     literature.sources
+  LEFT JOIN
+    almanac_classifiers.chip_predictions
     USING (merged_id)
-  WHERE dataset = "openalex"
+  WHERE sources.dataset = "openalex"
 ),
 
 llm_pubs AS (
   SELECT
-    orig_id,
-    label AS is_llm
+    sources.orig_id,
+    if(llm_predictions.merged_id IS NULL, FALSE, TRUE) AS is_llm
   FROM
-    almanac_classifiers.llm_classifier_predictions
+    ai_pubs
+  -- Get the merged_id for each OA orig_id from sources, which should be 1:1
   INNER JOIN
     literature.sources
-    USING (merged_id)
-  WHERE dataset = "openalex"
+    ON ai_pubs.id = sources.orig_id
+  -- llm_predictions contains merged_ids for predicted-true pubs
+  LEFT JOIN
+    almanac_classifiers.llm_predictions
+    ON sources.merged_id = llm_predictions.merged_id
+  WHERE sources.dataset = "openalex"
 ),
 
 language_id AS (
   SELECT DISTINCT
     id,
-    LOWER(
-      IF(title_cld2_lid_success AND title_cld2_lid_is_reliable, title_cld2_lid_first_result, NULL)
+    lower(
+      if(
+        title_cld2_lid_success AND title_cld2_lid_is_reliable,
+        title_cld2_lid_first_result,
+        NULL
+      )
     ) AS title_language,
-    LOWER(IF(
-      abstract_cld2_lid_success AND abstract_cld2_lid_is_reliable, abstract_cld2_lid_first_result, NULL
+    lower(if(
+      abstract_cld2_lid_success AND abstract_cld2_lid_is_reliable,
+      abstract_cld2_lid_first_result,
+      NULL
     )) AS abstract_language
   FROM
     staging_literature.all_metadata_with_cld2_lid
 )
 
 SELECT
-  id,
-  title_language,
-  abstract_language,
+  works.id,
+  language_id.title_language,
+  language_id.abstract_language,
   --  top_level1_fields,
-  is_ai,
-  is_nlp,
-  is_cv,
-  is_robotics,
-  is_cyber,
-  is_ai_safety,
-  is_chip_design_fabrication,
-  is_llm
+  ai_pubs.is_ai,
+  ai_pubs.is_nlp,
+  ai_pubs.is_cv,
+  ai_pubs.is_robotics,
+  ai_pubs.is_cyber,
+  ai_safety_pubs.is_ai_safety,
+  chip_pubs.is_chip_design_fabrication,
+  llm_pubs.is_llm
 FROM
   openalex.works
--- LEFT JOIN
---   top_fields
---   USING (merged_id)
 LEFT JOIN
   ai_pubs
-  ON id = ai_pubs.orig_id
+  ON works.id = ai_pubs.orig_id
 LEFT JOIN
   ai_safety_pubs
-  ON id = ai_safety_pubs.orig_id
+  ON works.id = ai_safety_pubs.orig_id
 LEFT JOIN
   chip_pubs
-  ON id = chip_pubs.orig_id
+  ON works.id = chip_pubs.orig_id
 LEFT JOIN
   llm_pubs
-  ON id = llm_pubs.orig_id
+  ON works.id = llm_pubs.orig_id
 LEFT JOIN
   language_id
-  USING (id)
+  ON works.id = language_id.id


### PR DESCRIPTION
There are three groups of changes in this PR:
- On 2024-04-22 in https://github.com/georgetown-cset/cset_openalex/commit/1d703f636e55194e3d471b7f962fa8add56463ae we dropped fields from the data by commenting out the relevant CTEs. I've deleted the commented-out lines for now; I'll add fields in a separate PR.
- Switching from OA-specific predictions to MAC predictions, for efficiency, since OA is now our preferred metadata source in MAC.
- Using the new locations for research almanac predictions.